### PR TITLE
Add the two web interfaces that stood out in the meetup

### DIFF
--- a/bin/y-octant
+++ b/bin/y-octant
@@ -1,0 +1,15 @@
+#!/bin/sh
+[ -z "$DEBUG" ] || set -x
+set -e
+YBIN="$(dirname $0)"
+
+version=0.7.0
+
+bin_name=octant \
+  bin_version=v${version} \
+  Darwin_url=https://github.com/vmware/octant/releases/download/v${version}/octant_${version}_macOS-64bit.tar.gz \
+  Darwin_sha256=756924d8c0a593c75ced6a4ce4d7c5e7c3f04bc542b9bf355822811a9b27b6e4 \
+  bin_tgz_path=octant_0.7.0_macOS-64bit/octant \
+  y-bin-dependency-download 1>&2 || exit $?
+
+y-octant-v${version}-bin "$@" || exit $?

--- a/kube-web-view/kustomization.yaml
+++ b/kube-web-view/kustomization.yaml
@@ -1,0 +1,2 @@
+bases:
+- https://codeberg.org/solsson/kube-web-view/deploy?ref=kustomize-support

--- a/kube-web-view/kustomization.yaml
+++ b/kube-web-view/kustomization.yaml
@@ -1,2 +1,3 @@
+namespace: ystack
 bases:
 - https://codeberg.org/solsson/kube-web-view/deploy?ref=kustomize-support


### PR DESCRIPTION
Both of them look really useful. I suggest merge but no inclusion in `converge-generic/` for now, because URLs over `kubefwd` will not indicate which cluster we're in.