### PR TITLE
Try to get kubectl top on k3s to work reliably

### DIFF
--- a/metrics-server/resource-limits.yaml
+++ b/metrics-server/resource-limits.yaml
@@ -12,5 +12,5 @@ spec:
             memory: 100Mi
             cpu: 100m
           requests:
-            memory: 50Mi
-            cpu: 50m
+            memory: 100Mi
+            cpu: 100m

--- a/metrics-server/resource-limits.yaml
+++ b/metrics-server/resource-limits.yaml
@@ -9,8 +9,8 @@ spec:
       - name: metrics-server
         resources:
           limits:
-            memory: 50Mi
-            cpu: 50m
+            memory: 100Mi
+            cpu: 100m
           requests:
             memory: 50Mi
             cpu: 50m

--- a/metrics-server/resource-limits.yaml
+++ b/metrics-server/resource-limits.yaml
@@ -9,8 +9,8 @@ spec:
       - name: metrics-server
         resources:
           limits:
-            memory: 100Mi
+            memory: 50Mi
             cpu: 100m
           requests:
-            memory: 100Mi
+            memory: 50Mi
             cpu: 100m


### PR DESCRIPTION
I can't isolate the factors that get me working `kubectl top pods` but now I''ve had at least had one instance where it didn't work and I applied the higher limits and it started working.

What didn't have any effect on reliability was c8b1505902be4f5a895857ddbac0fbef64143d31.