### PR TITLE
Get rid of the "There is a new version" message

### DIFF
--- a/bin/y-skaffold
+++ b/bin/y-skaffold
@@ -5,14 +5,14 @@ YBIN="$(dirname $0)"
 
 [ "$1" = "dev" ] && echo "y-skaffold dev requires -n [namespace] as initial args" && exit 1
 
-version=1.0.0
+version=1.0.1
 
 bin_name=skaffold \
   bin_version=v${version} \
   Darwin_url=https://github.com/GoogleContainerTools/skaffold/releases/download/v${version}/skaffold-darwin-amd64 \
-  Darwin_sha256=5a7b4dad8dfa83129c2076e799fa5a1a004f8c40cae0bb024828d5b542a96a84 \
+  Darwin_sha256=331a6cc0b8bba838d484c65b413bf79e8d736bda0480988d7baf0a16cff25b30 \
   Linux_url=https://github.com/GoogleContainerTools/skaffold/releases/download/v${version}/skaffold-linux-amd64 \
-  Linux_sha256=f03cb2115cd510b6de8b024165b6621e453935faaf99b20c8cdf9933eec9b913 \
+  Linux_sha256=f53e84288e044a3281e43adbc571a03271b7ee1d7b21781cc2a47248501e3964 \
   y-bin-dependency-download || exit $?
 
 # https://skaffold.dev/docs/concepts/#local-development

--- a/bin/y-skaffold
+++ b/bin/y-skaffold
@@ -24,5 +24,6 @@ grep 'current-context: minikube' $KUBECONFIG && {
 
 # Y-stack opinions, where do we put them?
 SKAFFOLD_NO_PRUNE=true \
+SKAFFOLD_UPDATE_CHECK=false \
   \
   $YBIN/y-skaffold-v${version}-bin "$@" || echo $?


### PR DESCRIPTION
... if you run y-skaffold. Vanilla skaffold still defaults to update checking.