### PR TITLE
Add git_commit build arg to y-build

### DIFF
--- a/bin/y-build
+++ b/bin/y-build
@@ -52,7 +52,6 @@ esac
 
 OUTPUT="type=image,name=$IMAGE,push=true,registry.insecure=true"
 
-BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ");
 BUILD_TAG="$(echo $IMAGE | awk -F/ '{print $NF}' | awk -F@ '{print $1}' | awk -F: '{print $2}')"
 
 # https://github.com/Yolean/build-contract/blob/a7e1a96ccec79bf413d604c344679f7439c34b49/build-contract#L21
@@ -75,7 +74,6 @@ BUILDKIT_HOST=$BUILDKIT_HOST \
     --local context="$BUILD_CONTEXT" \
     --local dockerfile="$BUILD_CONTEXT_DOCKERFILE" \
     --opt build-arg:build_tag=$BUILD_TAG \
-    --opt build-arg:build_timestamp=$BUILD_TIMESTAMP \
     --opt build-arg:git_commit=$GIT_COMMIT \
     $IMPORT_CACHE \
     $EXPORT_CACHE \

--- a/bin/y-build
+++ b/bin/y-build
@@ -61,8 +61,6 @@ if [[ ! -z "$GIT_COMMIT" ]]; then
   if [[ ! -z "$GIT_STATUS" ]]; then
     GIT_COMMIT="$GIT_COMMIT-dev"
   fi
-  echo "  --- build-contract: This is a git repo and GIT_COMMIT=$GIT_COMMIT ---  "
-  export GIT_COMMIT
 fi
 
 echo "Build command:"

--- a/bin/y-build
+++ b/bin/y-build
@@ -52,7 +52,19 @@ esac
 
 OUTPUT="type=image,name=$IMAGE,push=true,registry.insecure=true"
 
+BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ");
 BUILD_TAG="$(echo $IMAGE | awk -F/ '{print $NF}' | awk -F@ '{print $1}' | awk -F: '{print $2}')"
+
+# https://github.com/Yolean/build-contract/blob/a7e1a96ccec79bf413d604c344679f7439c34b49/build-contract#L21
+GIT_COMMIT=$(git rev-parse --verify --short HEAD 2>/dev/null || echo '')
+if [[ ! -z "$GIT_COMMIT" ]]; then
+  GIT_STATUS=$(git status --untracked-files=no --porcelain=v2)
+  if [[ ! -z "$GIT_STATUS" ]]; then
+    GIT_COMMIT="$GIT_COMMIT-dev"
+  fi
+  echo "  --- build-contract: This is a git repo and GIT_COMMIT=$GIT_COMMIT ---  "
+  export GIT_COMMIT
+fi
 
 echo "Build command:"
 set -x
@@ -63,6 +75,8 @@ BUILDKIT_HOST=$BUILDKIT_HOST \
     --local context="$BUILD_CONTEXT" \
     --local dockerfile="$BUILD_CONTEXT_DOCKERFILE" \
     --opt build-arg:build_tag=$BUILD_TAG \
+    --opt build-arg:build_timestamp=$BUILD_TIMESTAMP \
+    --opt build-arg:git_commit=$GIT_COMMIT \
     $IMPORT_CACHE \
     $EXPORT_CACHE \
     $BUILDCTL_OPTS \

--- a/bin/y-skaffold
+++ b/bin/y-skaffold
@@ -5,14 +5,14 @@ YBIN="$(dirname $0)"
 
 [ "$1" = "dev" ] && echo "y-skaffold dev requires -n [namespace] as initial args" && exit 1
 
-version=1.2.0
+version=1.3.1
 
 bin_name=skaffold \
   bin_version=v${version} \
   Darwin_url=https://github.com/GoogleContainerTools/skaffold/releases/download/v${version}/skaffold-darwin-amd64 \
-  Darwin_sha256=16d6eb05991a304f2065f2cc443196212a1a68371db8c1e42265f5f68bff54d8 \
+  Darwin_sha256=e2f9eb8277e95db95384e2093afbb5bd571347ea065689d8cfd54bae2b301b9a \
   Linux_url=https://github.com/GoogleContainerTools/skaffold/releases/download/v${version}/skaffold-linux-amd64 \
-  Linux_sha256=8c435b3faab09f697724f4ae48bb0cf203ae8490c431db35329674ef2aab5660 \
+  Linux_sha256=ab5b4b832e63add8795cdecdd59f89055a8d0bd625de3e59ace918ecb25db27b \
   y-bin-dependency-download || exit $?
 
 # https://skaffold.dev/docs/concepts/#local-development

--- a/examples/basic-dev-inner-loop/backend/Dockerfile
+++ b/examples/basic-dev-inner-loop/backend/Dockerfile
@@ -1,7 +1,11 @@
 FROM node:10.16.3-alpine@sha256:77c898d0da5e7bfb6e05c9a64de136ba4e03889a72f3c298e95df822a38f450d
 
 ARG build_tag
+ARG build_timestamp
+ARG git_commit
 ENV BUILD_TAG=$build_tag
+ENV BUILD_TIMESTAMP=$build_timestamp
+ENV GIT_COMMIT=$git_commit
 
 WORKDIR /app
 EXPOSE 3000


### PR DESCRIPTION
Both of them are independent of the [tag policy](https://skaffold.dev/docs/pipeline-stages/taggers/) in skaffold.yaml

We discussed a BUILD_DATE env as well but it's probably trivial to substring from BUILD_TIMESTAMP in most environments.