### PR TITLE
Build a well known ystack-runner image

### DIFF
--- a/bin/y-bin-dependency-download
+++ b/bin/y-bin-dependency-download
@@ -15,9 +15,10 @@ case "$platform" in
   Linux )
     url=$Linux_url
     sha256=$Linux_sha256
-    [ -z "$bin_tgz_path" ] || \
-      [[ "$bin_tgz_path" =~ ^[^/]+$ ]] ||  \
-      bin_tgz_path="--wildcards */$(basename $bin_tgz_path)"
+    case "$bin_tgz_path" in
+      */*) bin_tgz_path="--wildcards */$(basename $bin_tgz_path)" ;;
+      *) ;;
+    esac
     ;;
   * )
     echo "Unsupported platform $platform" && exit 1

--- a/bin/y-build
+++ b/bin/y-build
@@ -9,17 +9,19 @@ BUILDCTL_OPTS="$@"
 # We could also build using Tekton, if Skaffold had a generic way to transfer the build context to a waitinig build step container
 
 # Settings
-REGISTRY=builds-registry.ystack.svc.cluster.local
-[ -z "$BUILDKIT_CACHE" ] && BUILDKIT_CACHE="type=registry,ref=$REGISTRY/ystack:buildcache"
+DEFAULT_REGISTRY=builds-registry.ystack.svc.cluster.local
+[ -z "$BUILDS_REGISTRY" ] && BUILDS_REGISTRY=$DEFAULT_REGISTRY
+[ -z "$PUSH_REGISTRY" ]   && PUSH_REGISTRY=$DEFAULT_REGISTRY
+[ -z "$BUILDKIT_CACHE" ]  && BUILDKIT_CACHE="type=registry,ref=$BUILDS_REGISTRY/ystack:buildcache"
 [ -z "$IMPORT_CACHE" ] && IMPORT_CACHE="--import-cache=$BUILDKIT_CACHE"
 [ -z "$EXPORT_CACHE" ] && EXPORT_CACHE="--export-cache=$BUILDKIT_CACHE"
 [ "$IMPORT_CACHE" = "false" ] && IMPORT_CACHE=""
 [ "$EXPORT_CACHE" = "false" ] && EXPORT_CACHE=""
 
-if [ "$(curl -s --connect-timeout 3 http://$REGISTRY/v2/)" != "{}" ]
+if [ "$(curl -s --connect-timeout 3 http://$BUILDS_REGISTRY/v2/)" != "{}" ]
 then
-  echo "ERROR Skaffold need local access to the builds registry for digest lookup after build"
-  echo "Registry: $REGISTRY"
+  echo "ERROR Skaffold need local access to the builds registry for digest lookup"
+  echo "Registry: $BUILDS_REGISTRY"
   echo "Look for y-stack's ingress or port-forward utilities"
   exit 1
 fi
@@ -37,7 +39,7 @@ fi
 
 [ -z "$IMAGE" ] && {
   name=${PWD##*/}
-  IMAGE="$REGISTRY/y-stack-temp-builds/$name"
+  IMAGE="$BUILDS_REGISTRY/y-stack-temp-builds/$name"
   echo "No IMAGE env (from for example Skaffold). Guessing: $IMAGE"
 }
 
@@ -46,8 +48,8 @@ command -v y-hook-build-pre && cd $BUILD_CONTEXT && y-hook-build-pre
 
 IMAGE=$IMAGE
 case "$IMAGE" in
-  $REGISTRY/* ) ;;
-  * ) echo "Only the ystack builds registry is supported at the moment. Got: $IMAGE" && exit 1 ;;
+  $PUSH_REGISTRY/* ) ;;
+  * ) echo "Output is restricted to PUSH_REGISRY=$PUSH_REGISTRY. Got: $IMAGE" && exit 1 ;;
 esac
 
 OUTPUT="type=image,name=$IMAGE,push=true,registry.insecure=true"

--- a/bin/y-build
+++ b/bin/y-build
@@ -61,7 +61,7 @@ GIT_COMMIT=$(git rev-parse --verify --short HEAD 2>/dev/null || echo '')
 if [[ ! -z "$GIT_COMMIT" ]]; then
   GIT_STATUS=$(git status --untracked-files=no --porcelain=v2)
   if [[ ! -z "$GIT_STATUS" ]]; then
-    GIT_COMMIT="$GIT_COMMIT-dev"
+    GIT_COMMIT="$GIT_COMMIT-dirty"
   fi
 fi
 

--- a/bin/y-build
+++ b/bin/y-build
@@ -17,6 +17,7 @@ DEFAULT_REGISTRY=builds-registry.ystack.svc.cluster.local
 [ -z "$EXPORT_CACHE" ] && EXPORT_CACHE="--export-cache=$BUILDKIT_CACHE"
 [ "$IMPORT_CACHE" = "false" ] && IMPORT_CACHE=""
 [ "$EXPORT_CACHE" = "false" ] && EXPORT_CACHE=""
+[ -z "$BUILDKIT_HOST" ] && BUILDKIT_HOST=tcp://buildkitd.ystack.svc.cluster.local:8547
 
 if [ "$(curl -s --connect-timeout 3 http://$BUILDS_REGISTRY/v2/)" != "{}" ]
 then
@@ -25,8 +26,6 @@ then
   echo "Look for y-stack's ingress or port-forward utilities"
   exit 1
 fi
-
-[ -z "$BUILDKIT_HOST" ] && BUILDKIT_HOST=tcp://buildkitd.ystack.svc.cluster.local:8547
 
 # Envs from Skaffold build custom
 # (but for now we simply ignore PUSH_IMAGE as it has no clear significance for in-cluster builds)

--- a/bin/y-skaffold
+++ b/bin/y-skaffold
@@ -22,6 +22,8 @@ grep 'current-context: minikube' $KUBECONFIG && {
   source $YBIN/y-devcluster-docker.env
 }
 
+[ ! -z "$SKAFFOLD_CACHE_ARTIFACTS" ] || docker version > /dev/null 2>&1 || SKAFFOLD_CACHE_ARTIFACTS=false
+
 # Y-stack opinions, where do we put them?
 SKAFFOLD_NO_PRUNE=true \
 SKAFFOLD_UPDATE_CHECK=false \

--- a/k3s/image/Dockerfile
+++ b/k3s/image/Dockerfile
@@ -1,3 +1,3 @@
-FROM rancher/k3s:v1.0.0@sha256:b9ba23e7e382554bb60b7db7ca14d78804a41931cf5ba1e9ca90d9edd92a5fd4
+FROM rancher/k3s:v1.17.2-k3s1@sha256:674c68efbb2190284ee25c73c03fd9755fa77ad983e068b43542013a6bfe61de
 
 COPY registries.yaml /etc/rancher/k3s/registries.yaml

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10@sha256:a5193c15d7705bc2be91781355c4932321c06c18914facdd113d5bfcace7f92d
+FROM ubuntu:20.04@sha256:7922db6447e9d1470e3bf821e8ff228d70c3593e822e980c58bf9185821ac645
 
 RUN set -ex; \
   export DEBIAN_FRONTEND=noninteractive; \
@@ -12,10 +12,10 @@ RUN set -ex; \
 
 RUN set -ex; \
   F=$(mktemp); \
-  curl -SLs https://dl.k8s.io/v1.16.3/kubernetes-client-linux-amd64.tar.gz \
+  curl -SLs https://dl.k8s.io/v1.17.2/kubernetes-client-linux-amd64.tar.gz \
     | tee $F \
     | tar xzf - --strip-components=3 -C /usr/local/bin/; \
-  echo "904604839bbf46c11c7934f6f906adbc968234044b9f3268b71c175241626f8d4076812aca789dc5aa2f85fd25a384ad779638231d4d94f3f3c6d043b5d9f062 $F" \
+  echo "c5cd8954953ea348318f207c99c9dcb679d73dbaf562ac72660f7dab85616fd45b0f349d49eae9ea1f6aac7cae5bba839bf70f40b8be686d35605ae147339399 $F" \
     | sha512sum -c -; \
   rm $F
 
@@ -37,7 +37,7 @@ ENV SKAFFOLD_UPDATE_CHECK=false
 COPY bin/y-skaffold /usr/local/src/ystack/bin/
 RUN y-skaffold
 
-COPY --from=gcr.io/go-containerregistry/github.com/google/go-containerregistry/cmd/crane@sha256:2ebe1fffc23ac887cde2718b46f6133511b089e358bc08baa4de465675a1188f \
+COPY --from=gcr.io/go-containerregistry/crane:aec8da010de25d23759d972d7896629d6ae897d8 \
   /ko-app/crane /usr/local/bin/crane
 
 COPY . /usr/local/src/ystack


### PR DESCRIPTION
We should run builds with [solsson/ystack-runner](https://hub.docker.com/r/solsson/ystack-runner) and deprecate [solsson/ystack-skaffold-runner](https://hub.docker.com/r/solsson/ystack-skaffold-runner) 

Also builds sometimes need to be pused to prod immediately, hence the container should respect an override through the new `PUSH_REGISTRY` env.